### PR TITLE
Update BaseDaoImpl.java

### DIFF
--- a/src/main/java/exam/dao/base/BaseDaoImpl.java
+++ b/src/main/java/exam/dao/base/BaseDaoImpl.java
@@ -101,7 +101,8 @@ public abstract class BaseDaoImpl<T> implements BaseDao<T> {
 			for(String key : orderbys.keySet()) {
 				sqlBuilder.append(key).append(" ").append(orderbys.get(key)).append(",");
 			}
-			sqlBuilder.deleteCharAt(sql.length() - 1);
+// 			sqlBuilder.deleteCharAt(sql.length() - 1);
+			sqlBuilder.deleteCharAt(sqlBuilder.toString().length() - 1);
 		}
 		//设置分页
 		int begin = (pageCode - 1) * pageSize;


### PR DESCRIPTION
这个错误导致在添加排序 条件的时候报错， 您原本想把末尾的 \， 符号删除掉， 但是 在排序内容不为空的情况下，您传错了对象，导致sql 错误（sqlBuilder.deleteCharAt(sql.length() - 1);）， 正确的写法应该为：sqlBuilder.deleteCharAt(sqlBuilder.toString().length() - 1);